### PR TITLE
add travis-ci build badge to readme

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,8 @@
 puppet-chocolatey
 =====================
 
+[![Build Status](https://travis-ci.org/rismoney/puppet-chocolatey.png?branch=master)](https://travis-ci.org/rismoney/puppet-chocolatey)
+
 ** Member of the rismoney suite of Windows Puppet Providers **
 
 This is a chocolatey package provider.  


### PR DESCRIPTION
The badge shows the current build status of the master branch
at trivis-ci.org. By showing only the master branch status,
branch builds can fail without impacting the perception of
the master branch.

@rismoney You'll need to merge this and push to rismoney/puppet-chocolatey to
initiate the 1st travis build against _your_ repo.
