### PR TITLE
Set Chocolatey Path

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -10,6 +10,9 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
   has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
   chocopath = ENV['ChocolateyInstall'].to_s
+  if chocopath.empty?
+    chocopath = 'C:\Chocolatey'  
+  end
   commands :chocolatey => chocopath + "/chocolateyInstall/chocolatey.cmd"
 
   def install


### PR DESCRIPTION
If ruby can not get the environment variable for ChocolateyInstall manually set the chocopath to 'C:\Chocolatey'
