### PR TITLE
Add support for new chocolatey install path. Fix for issue #29

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
 
   def self.chocolatey_command
-    chocopath = ENV['ChocolateyInstall'] || 'C:\Chocolatey'
+    chocopath = ENV['ChocolateyInstall'] || ('C:\Chocolatey' if File.directory?('C:\Chocolatey')) || 'C:\ProgramData\chocolatey'
 
     chocopath + "\\chocolateyInstall\\chocolatey.cmd"
   end


### PR DESCRIPTION
(GH-29) Add additional default installation path for chocolatey

chocolatey 0.9.8.24 comes with new installation path -
C:\ProgramData\chocolatey. When you install this version of chocolatey
and use the provider in the same puppet run you will get an error
message saying that the provider is not functional on this host.

This change addresses the issue by checking if the legacy installation path
is present. If it is not it defaults to the new installation path. The check for legacy path is to
avoid breaking the provider for hosts running older versions of chocolatey.
