### PR TITLE
fix chocolatey latest logic

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -51,7 +51,11 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << "-source" << resource[:source]
     end
 
-    chocolatey(*args)
+    if self.query
+      chocolatey(*args)
+    else
+      self.install
+    end 
   end
 
   # from puppet-dev mailing list
@@ -96,7 +100,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def latest
-    packages = []
+    package_ver = ''
 
     begin
       output = execpipe(latestcmd()) do |process|
@@ -106,13 +110,13 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
           if line.empty?; next; end
           # Example: ( latest        : 2013.08.19.155043 )
           values = line.split(':').collect(&:strip).delete_if(&:empty?)
-          return values[1]
+          package_ver = values[1]
         end
       end
     rescue Puppet::ExecutionFailure
       return nil
     end
-    packages
+    package_ver
   end
 
 end


### PR DESCRIPTION
The current chocolatey-update behavior states that if a package
is not installed, then chocolatey returns "nothing to update"

This commit, adjusts the ensure=>latest logic: specifically

Case: Package is not installed
Action: Provider will perform a chocolatey install
Result: the latest package installed

Case: Package is installed but oldIf
Action: Provider will run chocolatey update to the latest version
Result: the latest package installed

Case: Package is already on the latest version
Action: Provider will not do anything.
Result: the latest packaged installed
