### PR TITLE
fix chocolatey latest logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 # http://about.travis-ci.org/docs/user/getting-started/
+language: ruby
 
 rvm:
   - 1.8.7

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -51,7 +51,11 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << "-source" << resource[:source]
     end
 
-    chocolatey(*args)
+    if self.query
+      chocolatey(*args)
+    else
+      self.install
+    end 
   end
 
   # from puppet-dev mailing list
@@ -96,7 +100,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def latest
-    packages = []
+    package_ver = ''
 
     begin
       output = execpipe(latestcmd()) do |process|
@@ -106,13 +110,13 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
           if line.empty?; next; end
           # Example: ( latest        : 2013.08.19.155043 )
           values = line.split(':').collect(&:strip).delete_if(&:empty?)
-          return values[1]
+          package_ver = values[1]
         end
       end
     rescue Puppet::ExecutionFailure
       return nil
     end
-    packages
+    package_ver
   end
 
 end

--- a/spec/unit/chocolatey_spec.rb
+++ b/spec/unit/chocolatey_spec.rb
@@ -54,7 +54,7 @@ describe provider do
 
   describe "when installing" do
     it "should use a command without versioned package" do
-      @resource[:ensure] = :latest
+      @resource[:ensure] = :present
       @provider.expects(:chocolatey).with('install', 'chocolatey', nil)
       @provider.install
     end
@@ -74,12 +74,29 @@ describe provider do
   end
 
   describe "when updating" do
-    it "should use a command without versioned package" do
+    it "should use `chocolatey update` when ensure latest and package present" do
+      provider.stubs(:instances).returns [provider.new({
+        :ensure   => "1.2.3",
+        :name     => "chocolatey",
+        :provider => :chocolatey,
+      })]
       @provider.expects(:chocolatey).with('update', 'chocolatey', nil)
       @provider.update
     end
 
+    it "should use `chocolatey install` when ensure latest and package absent" do
+       provider.stubs(:instances).returns []
+       @provider.expects(:chocolatey).with('install', 'chocolatey', nil)
+       @provider.update
+    end
+
+
     it "should use source if it is specified" do
+       provider.expects(:instances).returns [provider.new({
+        :ensure   => "latest",
+        :name     => "chocolatey",
+        :provider => :chocolatey,
+      })]
       @resource[:source] = 'c:\packages'
       @provider.expects(:chocolatey).with('update','chocolatey', nil, '-source', 'c:\packages')
       @provider.update


### PR DESCRIPTION
The current chocolatey-update behavior states that if a package
is not installed, then chocolatey returns "nothing to update"

This commit, adjusts the ensure=>latest logic: specifically

Case: Package is not installed
Action: Provider will perform a chocolatey install
Result: the latest package installed

Case: Package is installed but oldIf
Action: Provider will run chocolatey update to the latest version
Result: the latest package installed

Case: Package is already on the latest version
Action: Provider will not do anything.
Result: the latest packaged installed

This also clarified variable name from latest method
packages is really package_ver
