### PR TITLE
Remove superfluous whitespace

### DIFF
--- a/tests/init.pp
+++ b/tests/init.pp
@@ -4,6 +4,5 @@
   package { $pkg:
     ensure          => 'latest',
     provider        => 'chocolatey',
- 
   }
 #}


### PR DESCRIPTION
Remove superfluous whitespace that can actually cause puppet-lint to
fail.
