### PR TITLE
Avoiding puppet returning 2 instead of 0

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -178,7 +178,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
           else
             values = line.split(' ')
           end
-          packages << new({ :name => values[0], :ensure => values[1], :provider => self.name })
+          packages << new({ :name => values[0].downcase, :ensure => values[1], :provider => self.name })
         end
       end
     rescue Puppet::ExecutionFailure


### PR DESCRIPTION
This small change avoids puppet to treturn 2 instead of 0 when there are no changes to be done.