### PR TITLE
Add custom fact for choco installpath.

### DIFF
--- a/lib/facter/choco_installpath.rb
+++ b/lib/facter/choco_installpath.rb
@@ -1,0 +1,13 @@
+Facter.add('choco_installpath') do
+  confine :kernel => 'windows'
+
+  setcode do
+    require 'win32/registry'
+
+    value = 'C:/ProgramData/Chocolatey'
+    Win32::Registry::HKEY_LOCAL_MACHINE.open('SYSTEM\CurrentControlSet\Control\Session Manager\Environment') do |reg|
+      value = reg['ChocolateyInstall'] if reg.has_key? 'ChocolateyInstall'
+    end
+    value
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,5 +5,5 @@
 #
 # NOTE: CURRENTLY NON-FUNCTIONAL
 class chocolatey::params {
-  $install_location = 'c:/ProgramData/chocolatey'
+  $install_location = $::choco_installpath,
 }


### PR DESCRIPTION
This includes a custom fact for chocolatey's installpath. It will
default to 'C:/ProgramData/Chocolatey', and then attempt to read a value
from the registry, in case it's been installed to a custom path.

The `$chocolatey::params::install_location` variable will default to
this custom fact, but can be overridden when declaring the class.

This means that the `$choco_installpath` fact will be set to the default
location on the first time the module is installed, but will then update
to the correct location, if chocolatey is installed to a non-default
location.

This is untested, so please validate before release. I don't know if the
registry object has a `.has_key?` method or not.