### PR TITLE
(GH-71) Use upgrade instead of install

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -82,13 +82,22 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def install
+    args = []
+    # also will need to address -sidebyside or -m in the install args to allow
+    # multiple versions to be installed.
+    if !choco_exe? || @resource[:name][/\A\S*/] =~ /\.config$/i
+      args << 'install'
+    else
+      args << 'upgrade'
+    end
+
     should = @resource.should(:ensure)
     case should
     when true, false, Symbol
-      args = 'install', @resource[:name][/\A\S*/]
+      args << @resource[:name][/\A\S*/]
     else
       # Add the package version
-      args = 'install', @resource[:name][/\A\S*/], '-version', @resource[:ensure]
+      args << @resource[:name][/\A\S*/] << '-version' << @resource[:ensure]
     end
 
     if choco_exe?

--- a/spec/unit/chocolatey_spec.rb
+++ b/spec/unit/chocolatey_spec.rb
@@ -88,13 +88,20 @@ describe provider do
 
       it "should use a command without versioned package" do
         resource[:ensure] = :present
-        @provider.expects(:chocolatey).with('install', 'chocolatey','-dvy', nil)
+        @provider.expects(:chocolatey).with('upgrade', 'chocolatey','-dvy', nil)
+        @provider.install
+      end
+
+      it "should call install instead of upgrade if package name ends with .config" do
+        resource[:name] = "packages.config"
+        resource[:ensure] = :present
+        @provider.expects(:chocolatey).with('install', 'packages.config','-dvy', nil)
         @provider.install
       end
 
       it "should use source if it is specified" do
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('install','chocolatey','-dvy', nil, '-source', 'c:\packages')
+        @provider.expects(:chocolatey).with('upgrade','chocolatey','-dvy', nil, '-source', 'c:\packages')
         @provider.install
       end
     end
@@ -170,9 +177,9 @@ describe provider do
         @provider.update
       end
 
-      it "should use `chocolatey install` when ensure latest and package absent" do
+      it "should use `chocolatey upgrade` when ensure latest and package absent" do
         provider.stubs(:instances).returns []
-        @provider.expects(:chocolatey).with('install', 'chocolatey', '-dvy', nil)
+        @provider.expects(:chocolatey).with('upgrade', 'chocolatey', '-dvy', nil)
         @provider.update
       end
 


### PR DESCRIPTION
When `ensure => $version`, the underlying package provider will call
install instead of upgrade if the package is already installed.
Chocolatey's default install behavior is to do nothing if a package is
already installed, even if there is a newer version available. In most
cases we can call upgrade, except when the installer is using a
packages.config.

We'll also need to address the use of side by side installs, which this
will remove the ability to do.

This closes #71.