### PR TITLE
improved module structure

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,9 +9,9 @@ class chocolatey::config inherits chocolatey {
   # user may link to - it could be an older version of
   # Chocolatey
   if versioncmp($::chocolateyversion, '0.9.9.0') >= 0 {
-    $_choco_exe_path = "$::{choco_install_location}\\bin\\choco.exe"
+    $_choco_exe_path = "${chocolatey::choco_install_location}\\bin\\choco.exe"
 
-    $_enable_autouninstaller = $::enable_autouninstaller ? {
+    $_enable_autouninstaller = $chocolatey::enable_autouninstaller ? {
       false => 'disable',
       default => 'enable'
     }
@@ -19,7 +19,7 @@ class chocolatey::config inherits chocolatey {
     exec { "chocolatey_autouninstaller_${_enable_autouninstaller}":
       path    => $::path,
       command => "${_choco_exe_path} feature -r ${_enable_autouninstaller} -n autoUninstaller",
-      unless  => "cmd.exe /c ${_choco_exe_path} feature list -r | findstr /X /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
+      unless  => "cmd.exe /c ${chocolatey::choco_install_location}\\bin\\choco.exe feature list -r | findstr /X /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,5 @@
 # chocolatey::config - Private class used for configuration
-class chocolatey::config {
+class chocolatey::config inherits chocolatey {
   assert_private()
 
   # this will require a second converge when choco is not
@@ -9,9 +9,9 @@ class chocolatey::config {
   # user may link to - it could be an older version of
   # Chocolatey
   if versioncmp($::chocolateyversion, '0.9.9.0') >= 0 {
-    $_choco_exe_path = "${chocolatey::choco_install_location}\\bin\\choco.exe"
+    $_choco_exe_path = "${choco_install_location}\\bin\\choco.exe"
 
-    $_enable_autouninstaller = $chocolatey::enable_autouninstaller ? {
+    $_enable_autouninstaller = $enable_autouninstaller ? {
       false => 'disable',
       default => 'enable'
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,9 +9,9 @@ class chocolatey::config inherits chocolatey {
   # user may link to - it could be an older version of
   # Chocolatey
   if versioncmp($::chocolateyversion, '0.9.9.0') >= 0 {
-    $_choco_exe_path = "${choco_install_location}\\bin\\choco.exe"
+    $_choco_exe_path = "$::{choco_install_location}\\bin\\choco.exe"
 
-    $_enable_autouninstaller = $enable_autouninstaller ? {
+    $_enable_autouninstaller = $::enable_autouninstaller ? {
       false => 'disable',
       default => 'enable'
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,16 +62,12 @@ class chocolatey (
   validate_integer($choco_install_timeout_seconds)
   validate_bool($enable_autouninstaller)
 
-  if (versioncmp($::serverversion, '3.4.0') >= 0) or (versioncmp($::clientversion, '3.4.0') >= 0) {
-    class { '::chocolatey::install': } ->
-    class { '::chocolatey::config': }
+  # Anchor this as per #8040 - this ensures that classes won't float off and
+  # mess everything up.  You can read about this at:
+  # http://docs.puppetlabs.com/puppet/2.7/reference/lang_containment.html#known-issues
+  anchor { 'chocolatey::begin': } ->
+  class { '::chocolatey::install': } ->
+  class { '::chocolatey::config': } ->
+  anchor { 'chocolatey::end': }
 
-    contain '::chocolatey::install'
-    contain '::chocolatey::config'
-  } else {
-    anchor {'before_chocolatey':} ->
-    class { '::chocolatey::install': } ->
-    class { '::chocolatey::config': } ->
-    anchor {'after_chocolatey':}
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,10 +49,10 @@ class chocolatey (
   $choco_install_timeout_seconds  = $::chocolatey::params::install_timeout_seconds,
   $chocolatey_download_url        = $::chocolatey::params::download_url,
   $enable_autouninstaller         = $::chocolatey::params::enable_autouninstaller
-) inherits ::chocolatey::params {
+) inherits chocolatey::params {
 
   validate_re($chocolatey_download_url,['^http\:\/\/','^https\:\/\/'],
-    "For chocolatey_download_url, if not using the default '${::chocolatey::params::download_url}', please use a Http/Https Url that downloads 'chocolatey.nupkg'."
+  "For chocolatey_download_url, if not using the default '${chocolatey_download_url}', please use a Http/Https Url that downloads 'chocolatey.nupkg'."
   )
   validate_bool($use_7zip)
   validate_string($choco_install_location)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,7 @@
 class chocolatey::install inherits chocolatey {
   assert_private()
 
-  $unzip_type   = $use_7zip ? {
+  $unzip_type   = $::use_7zip ? {
     true      => '7zip',
     default   => 'windows'
   }
@@ -13,7 +13,7 @@ class chocolatey::install inherits chocolatey {
     ensure    => present,
     variable  => 'ChocolateyInstall',
     mergemode => 'clobber',
-    value     => $choco_install_location,
+    value     => $::choco_install_location,
     notify    => Exec['install_chocolatey_official'],
   }
 
@@ -21,14 +21,14 @@ class chocolatey::install inherits chocolatey {
     ensure    => present,
     variable  => 'PATH',
     mergemode => 'prepend',
-    value     => "${choco_install_location}\\bin",
+    value     => "$::{choco_install_location}\\bin",
     notify    => Exec['install_chocolatey_official'],
   }
 
   exec { 'install_chocolatey_official':
     command  => template('chocolatey/InstallChocolatey.ps1.erb'),
-    creates  => "${choco_install_location}\\bin\\choco.exe",
+    creates  => "$::{choco_install_location}\\bin\\choco.exe",
     provider => powershell,
-    timeout  => $choco_install_timeout_seconds,
+    timeout  => $::choco_install_timeout_seconds,
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,9 +1,8 @@
 # chocolatey::install - Private class used for install of Chocolatey
-class chocolatey::install {
+class chocolatey::install inherits chocolatey {
   assert_private()
 
-  $download_url = $::chocolatey::chocolatey_download_url
-  $unzip_type   = $::chocolatey::use_7zip ? {
+  $unzip_type   = $use_7zip ? {
     true      => '7zip',
     default   => 'windows'
   }
@@ -14,7 +13,7 @@ class chocolatey::install {
     ensure    => present,
     variable  => 'ChocolateyInstall',
     mergemode => 'clobber',
-    value     => $::chocolatey::choco_install_location,
+    value     => $choco_install_location,
     notify    => Exec['install_chocolatey_official'],
   }
 
@@ -22,14 +21,14 @@ class chocolatey::install {
     ensure    => present,
     variable  => 'PATH',
     mergemode => 'prepend',
-    value     => "${::chocolatey::choco_install_location}\\bin",
+    value     => "${choco_install_location}\\bin",
     notify    => Exec['install_chocolatey_official'],
   }
 
   exec { 'install_chocolatey_official':
     command  => template('chocolatey/InstallChocolatey.ps1.erb'),
-    creates  => "${::chocolatey::choco_install_location}\\bin\\choco.exe",
+    creates  => "${choco_install_location}\\bin\\choco.exe",
     provider => powershell,
-    timeout  => $::chocolatey::choco_install_timeout_seconds,
+    timeout  => $choco_install_timeout_seconds,
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,7 @@
 class chocolatey::install inherits chocolatey {
   assert_private()
 
-  $unzip_type   = $::use_7zip ? {
+  $unzip_type   = $chocolatey::use_7zip ? {
     true      => '7zip',
     default   => 'windows'
   }
@@ -13,7 +13,7 @@ class chocolatey::install inherits chocolatey {
     ensure    => present,
     variable  => 'ChocolateyInstall',
     mergemode => 'clobber',
-    value     => $::choco_install_location,
+    value     => $chocolatey::choco_install_location,
     notify    => Exec['install_chocolatey_official'],
   }
 
@@ -21,14 +21,14 @@ class chocolatey::install inherits chocolatey {
     ensure    => present,
     variable  => 'PATH',
     mergemode => 'prepend',
-    value     => "$::{choco_install_location}\\bin",
+    value     => "${chocolatey::choco_install_location}\\bin",
     notify    => Exec['install_chocolatey_official'],
   }
 
   exec { 'install_chocolatey_official':
     command  => template('chocolatey/InstallChocolatey.ps1.erb'),
-    creates  => "$::{choco_install_location}\\bin\\choco.exe",
+    creates  => "${chocolatey::choco_install_location}\\bin\\choco.exe",
     provider => powershell,
-    timeout  => $::choco_install_timeout_seconds,
+    timeout  => $chocolatey::choco_install_timeout_seconds,
   }
 }


### PR DESCRIPTION
I made some changes based on puppetlabs-ntp module structure.
The reason is that on a real environment I couldn't install chocolatey with a simple command ```include chocolatey```.
Now it is possible to do so