### PR TITLE
Update config.pp to accomodate new choco feature list -r output

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class chocolatey::config {
     exec { "chocolatey_autouninstaller_${_enable_autouninstaller}":
       path    => $::path,
       command => "${_choco_exe_path} feature -r ${_enable_autouninstaller} -n autoUninstaller",
-      unless  => "cmd.exe /c ${_choco_exe_path} feature list -r | findstr /X /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
+      unless  => "cmd.exe /c ${_choco_exe_path} feature list -r | findstr /B /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
     }
   }
 }


### PR DESCRIPTION
The findstr fails to match on the new version of chocolatey 0.9.9.9.  This is less exact but ignores the descriptions after the enabled/disabled section.