### PR TITLE
(GH-86) avoid using stale version of chocolateyinstall env var

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,10 +16,13 @@ class chocolatey::config {
       default => 'enable'
     }
 
+# lint:ignore:80chars
     exec { "chocolatey_autouninstaller_${_enable_autouninstaller}":
-      path    => $::path,
-      command => "${_choco_exe_path} feature -r ${_enable_autouninstaller} -n autoUninstaller",
-      unless  => "cmd.exe /c ${_choco_exe_path} feature list -r | findstr /B /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
+      path        => $::path,
+      command     => "${_choco_exe_path} feature -r ${_enable_autouninstaller} -n autoUninstaller",
+      unless      => "cmd.exe /c ${_choco_exe_path} feature list -r | findstr /B /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
+      environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"]
     }
+# lint:endignore
   }
 }


### PR DESCRIPTION
in a case where chocolatey was recently installed but the shell
was not refreshed, the exec within could be run with a stale
path (ie C:\chocolatey) if a migration to C:\ProgramData\chocolatey
had recently occured.

In this scenario, a folder structure will be improperly created
in the legacy path.

This patch ensures that the exec uses the puppet specified value
for the install location.