### PR TITLE
# introduced parameter for chocolatey version, falls back to existing…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,7 @@ class chocolatey::config {
   # version less than 0.9.9 and we don't know what the
   # user may link to - it could be an older version of
   # Chocolatey
-  if versioncmp($::chocolateyversion, '0.9.9.0') >= 0 {
+  if versioncmp($chocolatey::chocolatey_version, '0.9.9.0') >= 0 {
     $_choco_exe_path = "${chocolatey::choco_install_location}\\bin\\choco.exe"
 
     $_enable_autouninstaller = $chocolatey::enable_autouninstaller ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,13 +57,16 @@
 #   `true`.
 # @param [Boolean] log_output Log output from the installer. Defaults to
 #   `false`.
+# @param [String] chocolatey_version chocolatey version, falls back to
+#   `$::chocolateyversion`.
 class chocolatey (
   $choco_install_location         = $::chocolatey::params::install_location,
   $use_7zip                       = $::chocolatey::params::use_7zip,
   $choco_install_timeout_seconds  = $::chocolatey::params::install_timeout_seconds,
   $chocolatey_download_url        = $::chocolatey::params::download_url,
   $enable_autouninstaller         = $::chocolatey::params::enable_autouninstaller,
-  $log_output                     = false
+  $log_output                     = false,
+  $chocolatey_version             = $::chocolatey::params::chocolatey_version
 ) inherits ::chocolatey::params {
 
   validate_re($chocolatey_download_url,['^http\:\/\/','^https\:\/\/','file\:\/\/\/'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,4 +5,5 @@ class chocolatey::params {
   $use_7zip                 = false
   $install_timeout_seconds  = 1500
   $enable_autouninstaller   = true
+  $chocolatey_version       = $::chocolateyversion
 }


### PR DESCRIPTION
Before you needed a fact to provide the chocolatey version. This fact could not be passed by other modules or via hiera. With this PR it is possible to provide the parameter like e.g. the installation path. 