### PR TITLE
Confine facts to Windows OS family.

### DIFF
--- a/lib/facter/choco_install_path.rb
+++ b/lib/facter/choco_install_path.rb
@@ -2,6 +2,7 @@ require 'pathname'
 require Pathname.new(__FILE__).dirname + '../' + 'puppet_x/chocolatey/chocolatey_install'
 
 Facter.add('choco_install_path') do
+  confine :osfamily => :windows
   setcode do
     PuppetX::Chocolatey::ChocolateyInstall.install_path
   end

--- a/lib/facter/chocolateyversion.rb
+++ b/lib/facter/chocolateyversion.rb
@@ -1,4 +1,5 @@
 Facter.add('chocolateyversion') do
+  confine :osfamily => :windows
   setcode do
     value = nil
 


### PR DESCRIPTION
A simple change to ensure that the two chocolatey facts only exist on Windows hosts.