### PR TITLE
Fixes the broken version selection feature

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,7 +22,7 @@ class chocolatey::config {
       path        => $::path,
       command     => "${_choco_exe_path} feature -r ${_enable_autouninstaller} -n autoUninstaller",
       unless      => "cmd.exe /c ${_choco_exe_path} feature list -r | findstr /B /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
-      environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"]
+      environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"],
     }
   }
 # lint:endignore

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,12 +69,11 @@ class chocolatey (
   $chocolatey_version             = $::chocolatey::params::chocolatey_version
 ) inherits ::chocolatey::params {
 
-
-validate_string($choco_install_location)
+  validate_string($choco_install_location)
 # lint:ignore:140chars
-validate_re($choco_install_location, '^\w\:',
-"Please use a full path for choco_install_location starting with a local drive. Reference choco_install_location => '${choco_install_location}'."
-)
+  validate_re($choco_install_location, '^\w\:',
+    "Please use a full path for choco_install_location starting with a local drive. Reference choco_install_location => '${choco_install_location}'."
+  )
 # lint:endignore
 
   validate_bool($use_7zip)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,8 +2,9 @@
 class chocolatey::install {
   assert_private()
 
-  $download_url = $::chocolatey::chocolatey_download_url
-  $unzip_type   = $::chocolatey::use_7zip ? {
+  $download_url       = $::chocolatey::chocolatey_download_url
+  $chocolatey_version = $::chocolatey::chocolatey_version
+  $unzip_type         = $::chocolatey::use_7zip ? {
     true      => '7zip',
     default   => 'windows'
   }
@@ -32,6 +33,6 @@ class chocolatey::install {
     provider    => powershell,
     timeout     => $::chocolatey::choco_install_timeout_seconds,
     logoutput   => $::chocolatey::log_output,
-    environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"]
+    environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"],
   }
 }

--- a/templates/InstallChocolatey.ps1.erb
+++ b/templates/InstallChocolatey.ps1.erb
@@ -23,6 +23,7 @@ $ErrorActionPreference = 'Stop'
 # variables
 $url = '<%= @download_url %>'
 $unzipMethod = '<%= @unzip_type %>'
+$version = '<%= @chocolatey_version %>'
 if ($env:TEMP -eq $null) {
   $env:TEMP = Join-Path $env:SystemDrive 'temp'
 }
@@ -31,6 +32,10 @@ $tempDir = Join-Path $chocTempDir "chocInstall"
 if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
 $file = Join-Path $tempDir "chocolatey.zip"
 $chocErrorLog = Join-Path $tempDir "chocError.log"
+
+if $version != '' {
+  $url = "${url}${version}"
+}
 
 # PowerShell v2/3 caches the output stream. Then it throws errors due
 # to the FileStream not being what is expected. Fixes "The OS handle's


### PR DESCRIPTION
The newest version of Chocolatey was breaking our puppet builds and I noticed the `chocolatey_version` parameter wasn't actually being used anywhere for specifying a version and the only version installed was the latest regardless of the passed value.

This PR downloads the version supplied, else it falls back to the current if it's not.

If you supply a version, say `0.9.10.3` it will call `https://chocolatey.org/api/v2/package/chocolatey/0.9.10.3` to get the version supplied.