### PR TITLE
Fix version parameter?

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -128,7 +128,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       end
 
       # Add the package version
-      args << @resource[:name][/\A\S*/] << '-version' << @resource[:ensure]
+      args << @resource[:name][/\A\S*/] << '--version' << @resource[:ensure]
     end
 
     if choco_exe?


### PR DESCRIPTION
Investigating a lot of error with puppet installation... It seems that according to https://github.com/chocolatey/choco/issues/842
 it must be `--version`  and not `-version` 
```
Notice: /Stage[main]/Profiles::Teamcity::Build_environment::Windows/Package[Microsoft.VisualStudio.QualityTools.UnitTest
Framework]/ensure: created
Error: Could not update: Execution of 'C:\ProgramData\chocolatey\bin\choco.exe upgrade microsoft-build-tools -version 14
.0.23107.10 -y  -source http://maven.adform.com/nexus/service/local/nuget/chocolatey-group/' returned 4294967295: Parsin
g -version resulted in exception:
 Cannot bundle unregistered option '-e'.
Chocolatey v0.10.0
Upgrading the following packages:
microsoft-build-tools
By upgrading you accept licenses for the packages.
microsoft-build-tools is not installed. Installing...

microsoft-build-tools v14.0.23107.10
Downloading microsoft-build-tools
  from 'http://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BEBE-70A83094FC5A/BuildTools_Full.exe'
Progress: 100% - Completed download of C:\Users\Administrator\AppData\Local\Temp\2\chocolatey\microsoft-build-tools\14.0
.23107.10\BuildTools_Full.exe (24.46 MB).
Download of BuildTools_Full.exe (24.46 MB) completed.
WARNING: Missing package checksums are not allowed (by default for HTTP/FTP,
 HTTPS when feature 'allowEmptyChecksumsSecure' is disabled) for
 safety and security reasons. Although we strongly advise against it,
 if you need this functionality, please set the feature
 'allowEmptyChecksums' ('choco feature enable -n
 allowEmptyChecksums')
 or pass in the option '--allow-empty-checksums'.
The integrity of the file 'BuildTools_Full.exe' from 'http://download.microsoft.com/download/E/E/D/EEDF18A8-4AED-4CE0-BE
BE-70A83094FC5A/BuildTools_Full.exe' has not been verified by a checksum in the package scripts.
Do you wish to allow the install to continue (not recommended)?
[Y] Yes [N] No (default is "N")
  Confirmation (`-y`) is set.
  Respond within 30 seconds or the default selection will be chosen.
ERROR: Empty checksums are no longer allowed by default for non-secure sources. Please ask the maintainer to add checksu
ms to this package. In the meantime if you need this package to work correctly, please enable the feature allowEmptyChec
ksums or provide the runtime switch '--allowEmptyChecksums'. We strongly advise against allowing empty checksums for HTT
P/FTP sources.
The upgrade of microsoft-build-tools was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\microsoft-build-tools\tools\chocolateyInstall.ps1'.
 See log for details.

Chocolatey upgraded 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - microsoft-build-tools (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\microsoft-build-tools\tools\ch
ocolateyInstall.ps1'.
 See log for details.
Error: /Stage[main]/Profiles::Teamcity::Build_environment::Windows/Package[microsoft-build-tools]/ensure: change from ab
sent to 14.0.23107.10 failed: Could not update: Execution of 'C:\ProgramData\chocolatey\bin\choco.exe upgrade microsoft-
build-tools -version 14.0.23107.10 -y  -source http://maven.adform.com/nexus/service/local/nuget/chocolatey-group/' retu
rned 4294967295: Parsing -version resulted in exception:
 Cannot bundle unregistered option '-e'.
Chocolatey v0.10.0
[..snip..]
```