### PR TITLE
Replaced references to c: with the respective environmental variables (%programdata%, %systemdrive%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Windows versus Chocolatey, let's take a look at the use case of installing git:
 # Using built-in provider
 package { "Git version 1.8.4-preview20130916":
   ensure    => installed,
-  source    => 'C:\temp\Git-1.8.4-preview20130916.exe',
+  source    => '${::systemdrive}\temp\Git-1.8.4-preview20130916.exe',
   install_options => ['/VERYSILENT']
 }
 ~~~
@@ -221,7 +221,7 @@ class {'chocolatey':
 
 ~~~puppet
 class {'chocolatey':
-  chocolatey_download_url         => 'file:///c:/location/of/chocolatey.0.9.9.9.nupkg',
+  chocolatey_download_url         => 'file:///${::systemdrive}/location/of/chocolatey.0.9.9.9.nupkg',
   use_7zip                        => false,
   choco_install_timeout_seconds   => 2700,
 }
@@ -231,7 +231,7 @@ class {'chocolatey':
 
 ~~~puppet
 class {'chocolatey':
-  chocolatey_download_url         => 'file:///c:/location/of/chocolatey.0.9.9.9.nupkg',
+  chocolatey_download_url         => 'file:///${::systemdrive}/location/of/chocolatey.0.9.9.9.nupkg',
   use_7zip                        => false,
   choco_install_timeout_seconds   => 2700,
   chocolatey_version              => '0.9.9.9',
@@ -319,7 +319,7 @@ package { 'notepadplusplus':
 package { 'notepadplusplus':
   ensure   => '6.7.5',
   provider => 'chocolatey',
-  source   => 'C:\local\folder\packages',
+  source   => '${::systemdrive}\local\folder\packages',
 }
 ~~~
 
@@ -343,7 +343,7 @@ package { 'notepadplusplus':
 package { 'notepadplusplus':
   ensure   => '6.7.5',
   provider => 'chocolatey',
-  source   => 'C:\local\folder\packages;https://chocolatey.org/api/v2/',
+  source   => '${::systemdrive}\local\folder\packages;https://chocolatey.org/api/v2/',
 }
 ~~~
 
@@ -363,12 +363,12 @@ package {'launchy':
 ### Install options with quotes / spaces
 The underlying installer may need quotes passed to it. This is possible, but not
 as intuitive.  The example below covers passing
-`/INSTALLDIR="C:\Program Files\somewhere"`.
+`/INSTALLDIR="%ProgramFiles%\somewhere"`.
 
 For this to be passed through with Chocolatey, you will need a set of double
 quotes surrounding the argument and two sets of double quotes surrounding the
 item that must be quoted (see [how to pass/options/switches](https://github.com/chocolatey/choco/wiki/CommandsReference#how-to-pass-options--switches)). This makes the
-string look like `-installArgs "/INSTALLDIR=""C:\Program Files\somewhere"""` for
+string look like `-installArgs "/INSTALLDIR=""%ProgramFile%\somewhere"""` for
 proper use with Chocolatey.
 
 Then for Puppet to handle that appropriately, we must split on ***every*** space.
@@ -377,7 +377,7 @@ incorrectly. So this means it will look like the following:
 
 ~~~puppet
 install_options => ['-installArgs',
-  '"/INSTALLDIR=""C:\Program', 'Files\somewhere"""']
+  '"/INSTALLDIR=""%ProgramFiles%\somewhere"""']
 ~~~
 
 Make sure you have all of the right quotes - start it off with a single double
@@ -390,7 +390,7 @@ package {'mysql':
   ensure          => latest,
   provider        => 'chocolatey',
   install_options => ['-override', '-installArgs',
-    '"/INSTALLDIR=""C:\Program', 'Files\somewhere"""'],
+    '"/INSTALLDIR=""%ProgramFiles%\somewhere"""'],
 }
 ~~~
 
@@ -401,7 +401,7 @@ package {'mysql':
   ensure          => latest,
   provider        => 'chocolatey',
   install_options => ['-override', '-installArgs', '"'
-    '/INSTALLDIR=""C:\Program', 'Files\somewhere""',
+    '/INSTALLDIR=""%ProgramFiles%\somewhere""',
     '"'],
 }
 ~~~
@@ -433,9 +433,9 @@ This provider supports the `install_options` and `uninstall_options` attributes,
 which allow command-line options to be passed to the choco command. These options
 should be specified as documented below.
 
- * Required binaries: `choco.exe`, usually found in `C:\Program Data\chocolatey\bin\choco.exe`.
-   * The binary is searched for using the Environment Variable `ChocolateyInstall`, then by two known locations (`C:\Chocolatey\bin\choco.exe` and `C:\ProgramData\chocolatey\bin\choco.exe`).
-   * On Windows 2003 you should install Chocolatey to `C:\Chocolatey` or somewhere besides the default. **NOTE**: the root of `C:\` is not a secure location by default, so you may want to update the security on the folder.
+ * Required binaries: `choco.exe`, usually found in `%ProgramData%\chocolatey\bin\choco.exe`.
+   * The binary is searched for using the Environment Variable `ChocolateyInstall`, then by two known locations (`%systemdrive%\Chocolatey\bin\choco.exe` and `%ProgramData%\chocolatey\bin\choco.exe`).
+   * On Windows 2003 you should install Chocolatey to `%systemdrive%\Chocolatey` or somewhere besides the default. **NOTE**: the root of `C:\` is not a secure location by default, so you may want to update the security on the folder.
  * Supported features: `install_options`, `installable`, `uninstall_options`,
 `uninstallable`, `upgradeable`, `versionable`.
 
@@ -526,7 +526,7 @@ Used for managing installation and configuration of Chocolatey itself.
 
 ##### `choco_install_location`
 
-Where Chocolatey install should be located. This needs to be an absolute path starting with a drive letter e.g. `c:\`. Defaults to the currently detected install location based on the `ChocolateyInstall` environment variable, falls back to `'C:\ProgramData\chocolatey'`.
+Where Chocolatey install should be located. This needs to be an absolute path starting with a drive letter e.g. `c:\`. Defaults to the currently detected install location based on the `ChocolateyInstall` environment variable, falls back to `'%ProgramData%\chocolatey'`.
 
 ##### `use_7zip`
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ init:
 - git config --global user.email "chocolatey@realdimensions.net"
 - git config --global user.name "Chocolatey yo"
 - SET
-- 'mkdir C:\ProgramData\PuppetLabs\code && exit 0'
-- 'mkdir C:\ProgramData\PuppetLabs\facter && exit 0'
-- 'mkdir C:\ProgramData\PuppetLabs\hiera && exit 0'
-- 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
+- 'mkdir %ProgramData%\PuppetLabs\code && exit 0'
+- 'mkdir %ProgramData%\PuppetLabs\facter && exit 0'
+- 'mkdir %ProgramData%\PuppetLabs\hiera && exit 0'
+- 'mkdir %ProgramData%\PuppetLabs\puppet\var && exit 0'
 environment:
   matrix:
   - PUPPET_GEM_VERSION: ~> 3.0
@@ -25,7 +25,7 @@ environment:
 matrix:
   fast_finish: true
 install:
-- SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
+- SET PATH=$SystemDrive%\Ruby%RUBY_VER%\bin;%PATH%
 - gem install bundler --quiet --no-ri --no-rdoc
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
 matrix:
   fast_finish: true
 install:
-- SET PATH=$SystemDrive%\Ruby%RUBY_VER%\bin;%PATH%
+- SET PATH=%SystemDrive%\Ruby%RUBY_VER%\bin;%PATH%
 - gem install bundler --quiet --no-ri --no-rdoc
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -42,9 +42,9 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   def self.chocolatey_command
     if Puppet::Util::Platform.windows?
       #default_location = $::choco_installpath || ENV['ALLUSERSPROFILE'] + '\chocolatey'
-      chocopath = ('C:\ProgramData\chocolatey' if file_exists?('C:\ProgramData\chocolatey\bin\choco.exe')) ||
+      chocopath = (ENV['ProgramData'] + '\chocolatey' if file_exists?(ENV['ProgramData'] + '\chocolatey\bin\choco.exe')) ||
           (ENV['ChocolateyInstall'] if ENV['ChocolateyInstall'] && file_exists?("#{ENV['ChocolateyInstall']}\\bin\\choco.exe")) ||
-          ('C:\Chocolatey' if file_exists?('C:\Chocolatey\bin\choco.exe')) ||
+          (ENV['SystemDrive'] + '\Chocolatey' if file_exists?(ENV['SystemDrive'] + '\Chocolatey\bin\choco.exe')) ||
           "#{ENV['ALLUSERSPROFILE']}\\chocolatey"
 
       chocopath += '\bin\choco.exe'

--- a/lib/puppet_x/chocolatey/chocolatey_install.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_install.rb
@@ -17,7 +17,7 @@ module PuppetX
         end
       end
 
-      value || 'C:\ProgramData\chocolatey'
+      value || ENV['ProgramData'] + '\chocolatey'
       end
 
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@
 #
 # @example Use a file chocolatey.0.9.9.9.nupkg for installation
 #   class {'chocolatey':
-#     chocolatey_download_url         => 'file:///c:/location/of/chocolatey.0.9.9.9.nupkg',
+#     chocolatey_download_url         => 'file:///${::systemdrive}/location/of/chocolatey.0.9.9.9.nupkg',
 #     use_7zip                        => false,
 #     choco_install_timeout_seconds   => 2700,
 #   }
@@ -39,7 +39,7 @@
 #   located. This needs to be an absolute path starting with a drive letter
 #   e.g. `c:\`. Defaults to the currently detected install location based on
 #   the `ChocolateyInstall` environment variable, falls back to
-#   `'C:\ProgramData\chocolatey'`.
+#   `'%ProgramData%\chocolatey'`.
 # @param [Boolean] use_7zip Whether to use built-in shell or allow installer
 #   to download 7zip to extract `chocolatey.nupkg` during installation.
 #   Defaults to `false`.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # chocolatey::params - Default parameters
 class chocolatey::params {
-  $install_location         = $::choco_install_path # default is C:\ProgramData\chocolatey
+  $install_location         = $::choco_install_path # default is %ProgramData%\chocolatey
   $download_url             = 'https://chocolatey.org/api/v2/package/chocolatey/'
   $use_7zip                 = false
   $install_timeout_seconds  = 1500

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'chocolatey' do
       let(:facts) {
         {
           :chocolateyversion  => '0.9.8.33',
-          :choco_install_path => 'C:\ProgramData\chocolatey',
+          :choco_install_path => ENV['ProgramData'] + '\chocolatey',
         }
       }
 
@@ -20,7 +20,7 @@ RSpec.describe 'chocolatey' do
           it { is_expected.not_to contain_exec("chocolatey_autouninstaller_#{feature_enable}") }
 
           it {
-            is_expected.not_to contain_exec("chocolatey_autouninstaller_#{feature_enable}").with_command("C:\\ProgramData\\chocolatey\\bin\\choco.exe feature -r #{feature_enable} -n autoUninstaller")
+            is_expected.not_to contain_exec("chocolatey_autouninstaller_#{feature_enable}").with_command("%ProgramData%\\chocolatey\\bin\\choco.exe feature -r #{feature_enable} -n autoUninstaller")
           }
         end
       end
@@ -30,7 +30,7 @@ RSpec.describe 'chocolatey' do
       let(:facts) {
         {
           :chocolateyversion  => '0',
-          :choco_install_path => 'C:\ProgramData\chocolatey',
+          :choco_install_path => ENV['ProgramData'] + '\chocolatey',
         }
       }
 
@@ -44,7 +44,7 @@ RSpec.describe 'chocolatey' do
           it { is_expected.not_to contain_exec("chocolatey_autouninstaller_#{feature_enable}") }
 
           it {
-            is_expected.not_to contain_exec("chocolatey_autouninstaller_#{feature_enable}").with_command("C:\\ProgramData\\chocolatey\\bin\\choco.exe feature -r #{feature_enable} -n autoUninstaller")
+            is_expected.not_to contain_exec("chocolatey_autouninstaller_#{feature_enable}").with_command("%ProgramData%\\chocolatey\\bin\\choco.exe feature -r #{feature_enable} -n autoUninstaller")
           }
         end
       end
@@ -54,7 +54,7 @@ RSpec.describe 'chocolatey' do
       let(:facts) {
         {
           :chocolateyversion  => '0.9.9.8',
-          :choco_install_path => 'C:\ProgramData\chocolatey',
+          :choco_install_path => ENV['ProgramData'] + '\chocolatey',
         }
       }
 
@@ -68,7 +68,7 @@ RSpec.describe 'chocolatey' do
           it { is_expected.to contain_exec("chocolatey_autouninstaller_#{feature_enable}") }
 
           it {
-            is_expected.to contain_exec("chocolatey_autouninstaller_#{feature_enable}").with_command("C:\\ProgramData\\chocolatey\\bin\\choco.exe feature -r #{feature_enable} -n autoUninstaller")
+            is_expected.to contain_exec("chocolatey_autouninstaller_#{feature_enable}").with_command("%ProgramData%\\chocolatey\\bin\\choco.exe feature -r #{feature_enable} -n autoUninstaller")
           }
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,7 @@ describe 'chocolatey' do
   let(:facts) {
     {
       :chocolateyversion  => '0.9.9.8',
-      :choco_install_path => 'C:\ProgramData\chocolatey',
+      :choco_install_path => ENV['ProgramData'] + '\chocolatey',
     }
   }
 
@@ -26,7 +26,7 @@ describe 'chocolatey' do
   end
 
   context "chocolatey_download_url =>" do
-    ['https://chocolatey.org/api/v2/package/chocolatey/','http://location','file:///c:/somwhere/chocolatey.nupkg'].each do |param_value|
+    ['https://chocolatey.org/api/v2/package/chocolatey/','http://location','file:///%systemdrive%/somwhere/chocolatey.nupkg'].each do |param_value|
       context "#{param_value}" do
         let (:params) {{
           :chocolatey_download_url => param_value
@@ -74,7 +74,7 @@ describe 'chocolatey' do
   end
 
   context "choco_install_location =>" do
-    ['C:\\ProgramData\\chocolatey','D:\\somewhere'].each do |param_value|
+    [ENV['ProgramData'] + '\\chocolatey','D:\\somewhere'].each do |param_value|
       context "#{param_value}" do
         let (:params) {{
           :choco_install_location => param_value

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'chocolatey' do
   let(:facts) {
     {
       :chocolateyversion  => '0.9.9.8',
-      :choco_install_path => 'C:\ProgramData\chocolatey',
+      :choco_install_path => ENV['ProgramData'] + '\chocolatey',
     }
   }
 
@@ -18,7 +18,7 @@ RSpec.describe 'chocolatey' do
     it { is_expected.to contain_windows_env('chocolatey_PATH_env').with_variable('PATH') }
     it { is_expected.to contain_windows_env('chocolatey_PATH_env').that_notifies('Exec[install_chocolatey_official]') }
 
-    ['c:\local_folder', "C:\\ProgramData\\chocolatey"].each do |param_value|
+    ['%SystemDrive%\local_folder', "%ProgramData%\\chocolatey"].each do |param_value|
         context "choco_install_location => #{param_value}" do
         let(:params) {{ :choco_install_location => param_value }}
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ end
 
 RSpec.configure do |c|
   # set the environment variable before files are loaded, otherwise it is too late
-  ENV['ChocolateyInstall'] = 'c:\blah'
+  ENV['ChocolateyInstall'] = ENV['SystemDrive'] + '\blah'
 
   # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/mock-framework-integration/mock-with-mocha!
   c.mock_framework = :mocha

--- a/spec/unit/chocolatey_spec.rb
+++ b/spec/unit/chocolatey_spec.rb
@@ -22,17 +22,17 @@ describe provider do
   end
 
   it "should find chocolatey install location based on ChocolateyInstall environment variable", :if => Puppet.features.microsoft_windows? do
-    @provider.class.expects(:file_exists?).with('C:\ProgramData\chocolatey\bin\choco.exe').returns(false)
-    @provider.class.expects(:file_exists?).with('c:\blah\bin\choco.exe').returns(true)
+    @provider.class.expects(:file_exists?).with(ENV['ProgramData'] + '\chocolatey\bin\choco.exe').returns(false)
+    @provider.class.expects(:file_exists?).with(ENV['SystemDrive'] + '\blah\bin\choco.exe').returns(true)
     # this is a placeholder, it is already set in spec_helper
-    ENV['ChocolateyInstall'] = 'c:\blah'
-    @provider.class.chocolatey_command.should == 'c:\blah\bin\choco.exe'
+    ENV['ChocolateyInstall'] = ENV['SystemDrive'] + '\blah'
+    @provider.class.chocolatey_command.should == ENV['SystemDrive'] + '\blah\bin\choco.exe'
   end
 
   it "should find chocolatey install location based on default location", :if => Puppet.features.microsoft_windows? do
-    @provider.class.expects(:file_exists?).with('C:\ProgramData\chocolatey\bin\choco.exe').returns(false)
-    @provider.class.expects(:file_exists?).with('c:\blah\bin\choco.exe').returns(false)
-    @provider.class.expects(:file_exists?).with('C:\Chocolatey\bin\choco.exe').returns(false)
+    @provider.class.expects(:file_exists?).with(ENV['ProgramData'] + '\chocolatey\bin\choco.exe').returns(false)
+    @provider.class.expects(:file_exists?).with(ENV['SystemDrive'] + '\blah\bin\choco.exe').returns(false)
+    @provider.class.expects(:file_exists?).with(ENV['SystemDrive'] + '\Chocolatey\bin\choco.exe').returns(false)
     @provider.class.expects(:file_exists?).with("#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin\\choco.exe").returns(true)
     @provider.class.chocolatey_command.should == "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin\\choco.exe"
     @provider.class.chocolatey_command
@@ -67,8 +67,8 @@ describe provider do
       resource[:source].should be_nil
     end
 
-    it "should accept c:\\packages" do
-      resource[:source] = 'c:\packages'
+    it "should accept " + ENV['SystemDrive'] + "\\packages" do
+      resource[:source] = ENV['SystemDrive'] + '\packages'
     end
 
     it "should accept http://somelocation/packages" do
@@ -106,8 +106,8 @@ describe provider do
       end
 
       it "should use source if it is specified" do
-        resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('install','chocolatey','-y', nil, '-source', 'c:\packages')
+        resource[:source] = ENV['SystemDrive'] + '\packages'
+        @provider.expects(:chocolatey).with('install','chocolatey','-y', nil, '-source', ENV['SystemDrive'] + '\packages')
         @provider.install
       end
     end
@@ -130,8 +130,8 @@ describe provider do
       end
 
       it "should use source if it is specified" do
-        resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('install','chocolatey', nil, '-source', 'c:\packages')
+        resource[:source] = ENV['SystemDrive'] + '\packages'
+        @provider.expects(:chocolatey).with('install','chocolatey', nil, '-source', ENV['SystemDrive'] + '\packages')
         @provider.install
       end
     end
@@ -175,7 +175,7 @@ describe provider do
       end
 
       it "should use ignore source if it is specified" do
-        resource[:source] = 'c:\packages'
+        resource[:source] = ENV['SystemDrive'] + '\packages'
         @provider.expects(:chocolatey).with('uninstall','chocolatey','-fy', nil)
         @provider.uninstall
       end
@@ -192,8 +192,8 @@ describe provider do
       end
 
       it "should use source if it is specified" do
-        resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('uninstall','chocolatey', nil, '-source', 'c:\packages')
+        resource[:source] = ENV['SystemDrive'] + '\packages'
+        @provider.expects(:chocolatey).with('uninstall','chocolatey', nil, '-source', ENV['SystemDrive'] + '\packages')
         @provider.uninstall
       end
     end
@@ -227,8 +227,8 @@ describe provider do
           :name     => "chocolatey",
           :provider => :chocolatey,
         })]
-        resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('upgrade','chocolatey', '-y', nil, '-source', 'c:\packages')
+        resource[:source] = ENV['SystemDrive'] + '\packages'
+        @provider.expects(:chocolatey).with('upgrade','chocolatey', '-y', nil, '-source', ENV['SystemDrive'] + '\packages')
         @provider.update
       end
     end
@@ -260,8 +260,8 @@ describe provider do
           :name     => "chocolatey",
           :provider => :chocolatey,
         })]
-        resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('update','chocolatey', nil, '-source', 'c:\packages')
+        resource[:source] = ENV['SystemDrive'] + '\packages'
+        @provider.expects(:chocolatey).with('update','chocolatey', nil, '-source', ENV['SystemDrive'] + '\packages')
         @provider.update
       end
     end
@@ -286,9 +286,9 @@ describe provider do
       end
 
       it "should use source if it is specified" do
-        resource[:source] = 'c:\packages'
-        @provider.send(:latestcmd).should == [choco_command, 'upgrade', '--noop', 'chocolatey','-r', '-source', 'c:\packages']
-        #@provider.expects(:chocolatey).with('version', 'chocolatey', '-source', 'c:\packages')
+        resource[:source] = ENV['SystemDrive'] + '\packages'
+        @provider.send(:latestcmd).should == [choco_command, 'upgrade', '--noop', 'chocolatey','-r', '-source', ENV['SystemDrive'] + '\packages']
+        #@provider.expects(:chocolatey).with('version', 'chocolatey', '-source', ENV['SystemDrive'] + '\packages')
         #@provider.latest
       end
     end
@@ -303,9 +303,9 @@ describe provider do
       end
 
       it "should use source if it is specified" do
-        resource[:source] = 'c:\packages'
-        @provider.send(:latestcmd).should == [choco_command, 'version', 'chocolatey', '-source', 'c:\packages', '| findstr /R "latest" | findstr /V "latestCompare"']
-        #@provider.expects(:chocolatey).with('version', 'chocolatey', '-source', 'c:\packages')
+        resource[:source] = ENV['SystemDrive'] + '\packages'
+        @provider.send(:latestcmd).should == [choco_command, 'version', 'chocolatey', '-source', ENV['SystemDrive'] + '\packages', '| findstr /R "latest" | findstr /V "latestCompare"']
+        #@provider.expects(:chocolatey).with('version', 'chocolatey', '-source', ENV['SystemDrive'] + '\packages')
         #@provider.latest
       end
     end

--- a/spec/unit/facter/choco_install_path_spec.rb
+++ b/spec/unit/facter/choco_install_path_spec.rb
@@ -6,14 +6,14 @@ describe 'choco_install_path fact' do
 
   context 'on Windows', :if => Puppet::Util::Platform.windows? do
     it "should return install path from registry if it exists" do
-      expected_value = 'C:\somewhere'
+      expected_value = ENV['SystemDrive'] + '\somewhere'
       Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').returns(expected_value)
 
       subject.value.must == expected_value
     end
 
     it "should return the default install path if environment variable does not exist" do
-      expected_value = 'C:\ProgramData\chocolatey'
+      expected_value = ENV['ProgramData'] + '\chocolatey'
       Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
 
       subject.value.must == expected_value
@@ -21,7 +21,7 @@ describe 'choco_install_path fact' do
   end
 
   context 'on Linux', :if => Puppet.features.posix? do
-    its(:value) { should eql('C:\ProgramData\chocolatey') }
+    its(:value) { should eql(ENV['ProgramData'] + '\ProgramData\chocolatey') }
   end
 
   after :each do

--- a/templates/InstallChocolatey.ps1.erb
+++ b/templates/InstallChocolatey.ps1.erb
@@ -75,7 +75,7 @@ param (
     $downloader.Proxy = [System.Net.GlobalProxySelection]::GetEmptyWebProxy()
   }Else{
     $downloader.Proxy.Credentials=[System.Net.CredentialCache]::DefaultNetworkCredentials;
-  }  
+  }
   $downloader.DownloadFile($url, $file)
 }
 
@@ -117,7 +117,7 @@ Write-Output 'Ensuring chocolatey commands are on the path'
 $chocInstallVariableName = "ChocolateyInstall"
 $chocoPath = [Environment]::GetEnvironmentVariable($chocInstallVariableName, [System.EnvironmentVariableTarget]::User)
 if ($chocoPath -eq $null -or $chocoPath -eq '') {
-  $chocoPath = 'C:\ProgramData\Chocolatey'
+  $chocoPath = $env:ProgramData + '\Chocolatey'
 }
 
 $chocoBinPath = Join-Path $chocoPath 'bin'


### PR DESCRIPTION
The use of hardcoded references to C: cause issues with systems that don't have a C: drive or Windows is not installed in the C: drive. It's a best practice to use the environmental variables to reference the locations.
I replaced the references to c:\blah, c:\packages to %systemdrive%\blah and the references to c:\programdata to %ProgramData%